### PR TITLE
Authoritative validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ You... are AWESOME (go watch Kurt Kuenne's short film ["Validation"](https://www
 * Description note for shelved/static items
 * Path to appropriate thumbnail image
 * Sets the flag for delete protection
-* Sets the flag to 'Allow others to export to different formats', which opens up GDB downloads in Open Data.
+* Sets the flag to 'Allow others to export to different formats', which opens up GDB downloads in Open Data
+* Marks the item as Authoritative
 
 It also validates the tags (proper-case tags, don't repeat words found in the title) for all Feature Service items in the user's folders, regardless if they are found in the metatables or not.
 

--- a/checks.py
+++ b/checks.py
@@ -104,8 +104,11 @@ class ItemChecker:
             self.in_SGID = True
             self.new_title = self.metatable_dict[self.item.itemid][1]
             self.new_group = get_group_from_table(self.metatable_dict[self.item.itemid])
-            if self.metatable_dict[self.item.itemid][3] and self.metatable_dict[self.item.itemid][3].casefold() == 'y':
-                self.authoritative = 'public_authoritative'
+            if self.metatable_dict[self.item.itemid][3]:
+                if self.metatable_dict[self.item.itemid][3].casefold() == 'y':
+                    self.authoritative = 'public_authoritative'
+                elif self.metatable_dict[self.item.itemid][3].casefold() == 'd':
+                    self.authoritative = 'deprecated'
 
             feature_class_name = self.metatable_dict[self.item.itemid][0]
             self.results_dict['SGID_Name'] = feature_class_name
@@ -432,8 +435,8 @@ class ItemChecker:
                               'authoritative_old': '',
                               'authoritative_new': ''}
 
-        #: item.content_status can be 'authoritative', 'deprecated', or ''
-        if self.item.content_status != 'deprecated' and self.item.content_status != self.authoritative:
+        #: item.content_status can be 'public_authoritative', 'deprecated', or ''
+        if self.in_SGID and self.item.content_status != self.authoritative:
             authoritative_data = {'authoritative_fix': 'Y',
                                   'authoritative_old': f'{self.item.content_status}',
                                   'authoritative_new': self.authoritative}

--- a/checks.py
+++ b/checks.py
@@ -60,20 +60,15 @@ def get_group_from_table(metatable_dict_entry):
 
 class ItemChecker:
     '''
-    Class to validate an AGOL item. Uses a metatable entry if possible for some
-    information. Tags (partially), download options, and delete protection
-    don't rely on the metatable. __init__() gets what the values should be from
-    the metatable and stores them as instance variables. The x_check() methods
-    then use the instance variable to check against the item's existing data.
+    Class to validate an AGOL item. Uses a metatable entry for most information;
+    the tag check is the only check that doesn't rely on the metatables.
+    __init__() gets what the values should be from the metatable and stores them
+    as instance variables. The x_check() methods then use the instance variable
+    to check against the item's existing data.
 
-    This class is specific to a single item. General org-level data should be
-    stored in the Validate class and passed to methods if needed (like lists of
-    tags to uppercase, etc).
-
-    __init__() uses the metatable to set the desire state of the item as
-    instance variables. The various foo_check() methods use the ArcGIS API for
-    python to compare the AGOL item's current state against these instance
-    variables.
+    This class is specific to a single item. General org-level data (like lists
+    of tags to uppercase, etc) should be stored in the Validate class and
+    passed to methods if needed.
 
     The results_dict dictionary holds the results of every check that is
     completed. If a check isn't performed, it's results aren't added to the
@@ -440,6 +435,8 @@ class ItemChecker:
             authoritative_data = {'authoritative_fix': 'Y',
                                   'authoritative_old': f'{self.item.content_status}',
                                   'authoritative_new': self.authoritative}
+            #: item.content_status returns an empty string if it's not 
+            #: authoritative/deprecated.
             if not self.item.content_status:
                 authoritative_data['authoritative_old'] = '\' \''
 

--- a/checks.py
+++ b/checks.py
@@ -47,7 +47,7 @@ def get_group_from_table(metatable_dict_entry):
     the shelved category.
     '''
 
-    SGID_name, _, item_category = metatable_dict_entry
+    SGID_name, _, item_category, _ = metatable_dict_entry
 
     if item_category == 'shelved':
         group = 'AGRC Shelf'
@@ -104,7 +104,8 @@ class ItemChecker:
             self.in_SGID = True
             self.new_title = self.metatable_dict[self.item.itemid][1]
             self.new_group = get_group_from_table(self.metatable_dict[self.item.itemid])
-            self.authoritative = 'authoritative'
+            if self.metatable_dict[self.item.itemid][3] and self.metatable_dict[self.item.itemid][3].casefold() == 'y':
+                self.authoritative = 'public_authoritative'
 
             feature_class_name = self.metatable_dict[self.item.itemid][0]
             self.results_dict['SGID_Name'] = feature_class_name
@@ -431,11 +432,12 @@ class ItemChecker:
                               'authoritative_old': '',
                               'authoritative_new': ''}
 
-        if self.item.content_status != self.authoritative:
+        #: item.content_status can be 'authoritative', 'deprecated', or ''
+        if self.item.content_status != 'deprecated' and self.item.content_status != self.authoritative:
             authoritative_data = {'authoritative_fix': 'Y',
                                   'authoritative_old': f'{self.item.content_status}',
                                   'authoritative_new': self.authoritative}
-            #: item.content_status returns an empty string if it's not 
+            #: item.content_status returns an empty string if it's not
             #: authoritative/deprecated.
             if not self.item.content_status:
                 authoritative_data['authoritative_old'] = '\' \''

--- a/fixes.py
+++ b/fixes.py
@@ -269,3 +269,30 @@ class ItemFixer:
             return
 
         self.item_report['thumbnail_result'] = f'Thumbnail updated from {thumbnail_path}'
+
+    def authoritative_fix(self):
+        '''
+        Change the item.content_status to 'authoritative', 'deprecated', or
+        None (to reset).
+
+        Updates item_report with results for this fix:
+        {authoritative_result: result}
+        '''
+
+        new_authoritative = self.item_report['authoritative_new']
+        if self.item_report['authoritative_fix'].casefold() != 'y':
+            self.item_report['authoritative_result'] = 'No update needed for content status'
+            return
+
+        try:
+            self.item.content_status = new_authoritative
+            self.item_report['authoritative_result'] = f'Content status updated to "{new_authoritative}"'
+            return
+
+        except ValueError:
+            self.item_report['authoritative_result'] = f'Invalid new authoritative value "{new_authoritative}"'
+            return
+
+        except RuntimeError:
+            self.item_report['authoritative_result'] = f'User does not have privileges to change content status. Must use an AGOL account that is assigned the Administrator role.'
+            return

--- a/fixes.py
+++ b/fixes.py
@@ -283,6 +283,9 @@ class ItemFixer:
         '''
 
         new_authoritative = self.item_report['authoritative_new']
+        if not self.item_report['authoritative_new']:
+            new_authoritative = None  #: translate '' to None for arcgis api
+            
         if self.item_report['authoritative_fix'].casefold() != 'y':
             self.item_report['authoritative_result'] = 'No update needed for content status'
             return

--- a/fixes.py
+++ b/fixes.py
@@ -10,9 +10,9 @@ class ItemFixer:
     ItemChecker. Uses the item report dictionary created by ItemChecker for the
     item to determine what needs to be fixed and what values to use.
 
-    This class is specific to a single item. General org-level data should be
-    stored in the Validate class and passed to methods if needed (like
-    dictionary of groups and their ids).
+    This class is specific to a single item. General org-level data (like
+    dictionary of groups and their ids) should be stored in the Validate class
+    and passed to methods if needed.
 
     The results of each fix, or a note that a fix was not needed, are added to
     the item_report dictionary passed to the ItemFixer like thus:
@@ -255,6 +255,9 @@ class ItemFixer:
         '''
         Overwrite the thumbnail if the item is in one of the icon groups. The
         item_report dictionary should have the path to the new thumbnail.
+
+        Updates item_report with results for this fix:
+        {thumbnail_result: result}
         '''
 
         if self.item_report['thumbnail_fix'].casefold() != 'y':
@@ -294,5 +297,5 @@ class ItemFixer:
             return
 
         except RuntimeError:
-            self.item_report['authoritative_result'] = f'User does not have privileges to change content status. Must use an AGOL account that is assigned the Administrator role.'
+            self.item_report['authoritative_result'] = f'User does not have privileges to change content status. Please use an AGOL account that is assigned the Administrator role.'
             return

--- a/validate.py
+++ b/validate.py
@@ -97,7 +97,7 @@ class Validator:
             print('Getting metatable info...')
         duplicate_keys = []
 
-        meta_fields = ['TABLENAME', 'AGOL_ITEM_ID', 'AGOL_PUBLISHED_NAME']
+        meta_fields = ['TABLENAME', 'AGOL_ITEM_ID', 'AGOL_PUBLISHED_NAME', 'Authoritative']
         meta_dupes = self.read_metatable(self.metatable, meta_fields)
 
         agol_fields = ['TABLENAME', 'AGOL_ITEM_ID', 'AGOL_PUBLISHED_NAME', 'CATEGORY']
@@ -130,16 +130,17 @@ class Validator:
         with arcpy.da.SearchCursor(table, fields) as meta_cursor:
             for row in meta_cursor:
 
-                if len(fields) == 3:  #: AGOLItems table only has three fields
-                    table_sgid_name, table_agol_itemid, table_agol_name = row
+                if fields[-1] == 'Authoritative':  #: AGOLItems table's last field is "Authoritative"
+                    table_sgid_name, table_agol_itemid, table_agol_name, table_authoritative = row
                     table_category = 'SGID'
 
-                else:  #: Shelved table hosted in AGOL has four fields
+                else:  #: Shelved table hosted in AGOL's last field is "CATEGORY"
                     table_sgid_name, table_agol_itemid, table_agol_name, table_category = row
+                    table_authoritative = 'n'
 
                 if table_agol_itemid:  #: Don't evaluate null itemids
                     if table_agol_itemid not in self.metatable_dict:
-                        self.metatable_dict[table_agol_itemid] = [table_sgid_name, table_agol_name, table_category]
+                        self.metatable_dict[table_agol_itemid] = [table_sgid_name, table_agol_name, table_category, table_authoritative]
                     else:
                         duplicate_keys.append(table_agol_itemid)
 

--- a/validate.py
+++ b/validate.py
@@ -187,6 +187,7 @@ class Validator:
             checker.metadata_check()
             checker.description_note_check(self.static_note, self.shelved_note)
             checker.thumbnail_check(credentials.THUMBNAIL_DIR)
+            checker.authoritative_check()
 
             #: Add results to the report
             self.report_dict[itemid].update(checker.results_dict)
@@ -226,6 +227,7 @@ class Validator:
                 fixer.downloads_fix()
                 fixer.description_note_fix(self.static_note, self.shelved_note)
                 fixer.thumbnail_fix()
+                fixer.authoritative_fix()
 
                 update_status_keys = ['metadata_result', 'tags_result',
                                       'title_result', 'groups_result',
@@ -233,7 +235,8 @@ class Validator:
                                       'delete_protection_result',
                                       'downloads_result',
                                       'description_note_result',
-                                      'thumbnail_result']
+                                      'thumbnail_result',
+                                      'authoritative_result']
 
                 if self.verbose:
                     for status in update_status_keys:

--- a/validate.py
+++ b/validate.py
@@ -240,6 +240,9 @@ class Validator:
                         if 'No update needed for' not in item_report[status]:
                             print(f'\t{item_report[status]}')
 
+        except KeyboardInterrupt:
+            print('Interrupted by Ctrl-c')
+            raise
 
         finally:
             #: Convert dict to pandas df for easy writing

--- a/validate.py
+++ b/validate.py
@@ -42,10 +42,9 @@ class Validator:
 
     def __init__(self, verbose=False):
         '''
-        Create an arcgis.gis.GIS object for 'user' at 'portal'. Automatically
+        Create an arcgis.gis.GIS object using the user, portal, and password set in credentials.py. Automatically
         create a list of all the Feature Service objects in the user's folders
-        and a dictionary of each item's folder based on itemid. Read 'metatable'
-        and agol_table into a dictionary based on the itemid.
+        and a dictionary of each item's folder based on itemid. Read SDE and AGOL metatables into a dictionary based on the itemid.
         '''
 
         #: Metatables
@@ -149,20 +148,11 @@ class Validator:
 
     def check_items(self, report_dir=None):
         '''
-        For each hosted feature layer, check:
-            > Tags for malformed spacing, standard AGRC/SGID tags
-                item.update({'tags':[tags]})
-            > Group & Folder (?) to match source data category
-                gis.content.share(item, everyone=True, groups=<Open Data Group>)
-                item.move(folder)
-            > Delete Protection enabled
-                item.protect=True
-            > Downloads enabled
-                manager = arcgis.features.FeatureLayerCollection.fromitem(item).manager
-                manager.update_definition({ 'capabilities': 'Query,Extract' })
-            > Title against metatable
-                item.update({'title':title})
-            > Metadata against SGID (Waiting until 2.5's arcpy metadata tools?)
+        Instantiates an ItemChecker for each item and manually runs the
+        specified check methods. The results of the checks are saved in
+        self.report_dict, which can be used to guide the fixes. Exports the
+        final self.report_dict to a csv named checks_yyyy-mm-dd.csv in
+        'report_dir', if specified.
         '''
 
         for item in self.feature_service_items:
@@ -201,9 +191,10 @@ class Validator:
 
     def fix_items(self, report_dir=None):
         '''
-        Perform any needed fixes by looping through report dictionary and
-        checking the various _fix entries. Append results string to report
-        dictionary and write to report_path (if specified).
+        Instantiates an ItemFixer for each item and manually runs the specified
+        fix methods using data in self.report_dict. Appends results to
+        self.report_dict and writes the whole dictionary to a csv named
+        checks_yyyy-mm-dd.csv in 'report_path' (if specified).
         '''
 
         try:
@@ -218,7 +209,6 @@ class Validator:
                 fixer = fixes.ItemFixer(item, item_report)
 
                 fixer.metadata_fix()
-                # fixer.tags_or_title_fix()
                 fixer.tags_fix()
                 fixer.title_fix()
                 fixer.group_fix(self.groups_dict)


### PR DESCRIPTION
Implemented a checker/fixer for the mark as authoritative/deprecated settings based on a `y` or `d` respectively in `META.AGOLItems` `Authoritative` field. Also adds some try/except/finally handling for HTTP errors based on an Error 498 I got halfway through one test run, probably caused by a glitch in the connection to the AGOL portal.