### PR TITLE
feat: add default vis check, fixes #13

### DIFF
--- a/checks.py
+++ b/checks.py
@@ -471,6 +471,6 @@ class ItemChecker:
                 self.set_visibility = True
 
         if self.set_visibility:
-            fix_visibility = {'visibility_fix':'Y'}
+            fix_visibility['visibility_fix'] = 'Y'
 
         self.results_dict.update(fix_visibility)

--- a/checks.py
+++ b/checks.py
@@ -85,10 +85,12 @@ class ItemChecker:
         self.item = item
         self.metatable_dict = metatable_dict
 
+        #: These may or may not be used outside their specific check methods
         self.new_tags = []
         self.downloads = False
         self.protect = False
         self.static_shelved = None
+        self.set_visibility = False
 
         #: These maybe overwritten below if the item is in the SGID
         self.in_SGID = False
@@ -446,3 +448,29 @@ class ItemChecker:
                 authoritative_data['authoritative_old'] = '\' \''
 
         self.results_dict.update(authoritative_data)
+
+    def visibility_check(self):
+        '''
+        Make sure item's default visibility is set to True
+
+        Update results_dict with results for this item:
+                {'visibility_fix':''}
+        '''
+
+        fix_visibility = {'visibility_fix':'N'}
+
+        for layer in self.item.layers:
+            
+            #: Check if default vis is true; wrap in try/except for robustness
+            try:
+                properties = json.loads(str(layer.manager.properties))
+            except:
+                properties = None
+
+            if properties and not properties['defaultVisibility']:
+                self.set_visibility = True
+
+        if self.set_visibility:
+            fix_visibility = {'visibility_fix':'Y'}
+
+        self.results_dict.update(fix_visibility)

--- a/fixes.py
+++ b/fixes.py
@@ -302,3 +302,29 @@ class ItemFixer:
         except RuntimeError:
             self.item_report['authoritative_result'] = f'User does not have privileges to change content status. Please use an AGOL account that is assigned the Administrator role.'
             return
+
+    def visibility_fix(self):
+        '''
+        Access item's manager object and set it's defaultVisibility property
+        to True
+
+        Updates item_report with results for this fix:
+        {visibility_result: result}
+        '''
+
+        if self.item_report['visibility_fix'].casefold() != 'y':
+            self.item_report['visibility_result'] = 'No update needed for visibility'
+            return
+
+        success = True
+        for layer in self.item.layers:
+            visibility_result = layer.manager.update_definition({'defaultVisibility': True})
+
+            if not visibility_result['success']:
+                success= False
+
+        if not success:
+            self.item_report['visibility_result'] = f'Failed to set default visibility to True'
+            return
+
+        self.item_report['visibility_result'] = f'Default visibility set to True'

--- a/validate.py
+++ b/validate.py
@@ -195,6 +195,7 @@ class Validator:
                 checker.description_note_check(self.static_note, self.shelved_note)
                 checker.thumbnail_check(credentials.THUMBNAIL_DIR)
                 checker.authoritative_check()
+                checker.visibility_check()
 
                 #: Add results to the report
                 self.report_dict[itemid].update(checker.results_dict)
@@ -240,6 +241,7 @@ class Validator:
                 fixer.description_note_fix(self.static_note, self.shelved_note)
                 fixer.thumbnail_fix()
                 fixer.authoritative_fix()
+                fixer.visibility_fix()
 
                 update_status_keys = ['metadata_result', 'tags_result',
                                       'title_result', 'groups_result',
@@ -248,7 +250,8 @@ class Validator:
                                       'downloads_result',
                                       'description_note_result',
                                       'thumbnail_result',
-                                      'authoritative_result']
+                                      'authoritative_result',
+                                      'visibility_result']
 
 
                 for status in update_status_keys:


### PR DESCRIPTION
Adding `visibility_check()` to loop through the layers of any hosted feature service and see if the defaultVisibility property is False. If any layer is set to False, fix by setting all layers to True in `visibility_fix()`.