### PR TITLE
Fix: remove empty tags

### DIFF
--- a/checks.py
+++ b/checks.py
@@ -149,11 +149,13 @@ class ItemChecker:
             title = self.item.title
 
         #: Strip off any leading/trailing whitespace
-        orig_tags = [t.strip() for t in self.item.tags]
+        orig_tags = [t.strip() for t in self.item.tags if t.strip()]
 
         #: Add any tags in the metadata to list of tags to evaluate
         if self.arcpy_metadata and self.arcpy_metadata.tags:
-            orig_tags.extend([t.strip() for t in self.arcpy_metadata.tags.split(', ')])
+            orig_tags.extend([t.strip()
+                              for t in self.arcpy_metadata.tags.split(', ')
+                              if t.strip()])
 
         #: Evaluate existing tags
         for orig_tag in orig_tags:

--- a/fixes.py
+++ b/fixes.py
@@ -87,7 +87,7 @@ class ItemFixer:
 
         #: Was no update needed?
         if self.item_report['groups_fix'].casefold() != 'y':
-            self.item_report['groups_result'] = 'No update needed for grpi[s'
+            self.item_report['groups_result'] = 'No update needed for groups'
             return
 
         #: Share to everyone and groups


### PR DESCRIPTION
Any existing blank tags will now be removed. There are a couple places I think these can sneak in, but this should catch them.

The list of tags is built from checking any existing tags, any tags from the metadata, and adding a group tag if applicable. Now both existing tags and metadata tags are only added in the list comprehensions if they evaluate `True` after being `.lower()`ed.