### PR TITLE
Improve metadata upload

### DIFF
--- a/checks.py
+++ b/checks.py
@@ -1,6 +1,6 @@
 import json
 
-from os.path import join, exists
+from pathlib import Path
 
 import arcgis
 import arcpy
@@ -114,9 +114,9 @@ class ItemChecker:
 
             feature_class_name = self.metatable_dict[self.item.itemid][0]
             self.results_dict['SGID_Name'] = feature_class_name
-            self.feature_class_path = join(sde_path, feature_class_name)
-            if arcpy.Exists(self.feature_class_path):
-                self.arcpy_metadata = arcpy.metadata.Metadata(self.feature_class_path)
+            self.feature_class_path = Path(sde_path, feature_class_name)
+            if arcpy.Exists(str(self.feature_class_path)):
+                self.arcpy_metadata = arcpy.metadata.Metadata(str(self.feature_class_path))
 
         #: Get folder from SGID category if it's in the table
         if self.new_group == 'AGRC Shelf':
@@ -367,7 +367,7 @@ class ItemChecker:
         if self.arcpy_metadata and self.arcpy_metadata.xml != self.item.metadata:
             metadata_data = {'metadata_fix': 'Y',
                              'metadata_old': 'item.metadata from AGOL not shown due to length',
-                             'metadata_new': self.feature_class_path,
+                             'metadata_new': str(self.feature_class_path),
                              'metadata_note': ''}
 
             # Update flag for description note for shelved/static data
@@ -417,10 +417,10 @@ class ItemChecker:
             thumbnail_data = {'thumbnail_fix': 'N', 'thumbnail_path': 'Shelved'}
 
             if group.casefold() != 'shelf':
-                thumbnail_path = join(thumbnail_dir, f'{group}.png')
-                thumbnail_data = {'thumbnail_fix': 'Y', 'thumbnail_path': thumbnail_path}
+                thumbnail_path = Path(thumbnail_dir, f'{group}.png')
+                thumbnail_data = {'thumbnail_fix': 'Y', 'thumbnail_path': str(thumbnail_path)}
 
-                if not exists(thumbnail_path):
+                if not thumbnail_path.exists():
                     thumbnail_data = {'thumbnail_fix': 'N', 'thumbnail_path': f'Thumbnail not found: {thumbnail_path}'}
 
         self.results_dict.update(thumbnail_data)

--- a/credentials_template.py
+++ b/credentials_template.py
@@ -4,4 +4,5 @@ PASSWORD =  #: USERNAME's password
 DB =  #: Full path to sde connection file
 THUMBNAIL_DIR =  #: Directory with thumbnails named sgid_group.png
 METATABLE =  #: Full path to SGID.META.AGOLItems metatable
-AGOL_TABLE =   #: URL for Feature Service REST endpoint for AGOL-hosted metatable
+AGOL_TABLE =  #: URL for Feature Service REST endpoint for AGOL-hosted metatable
+XML_TEMPLATE =  #: Path to 'exact copy of.xslt' template

--- a/exact copy of.xslt
+++ b/exact copy of.xslt
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Processes ArcGIS metadata to create a copy of an item's metadata. -->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" >
+	<xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes" omit-xml-declaration="no" />
+
+	<!-- start processing all nodes and attributes in the XML document -->
+	<!-- any CDATA blocks in the original XML will be lost because they can't be handled by XSLT -->
+	<xsl:template match="/">
+		<xsl:apply-templates select="node() | @*" />
+	</xsl:template>
+
+	<!-- copy all nodes and attributes in the XML document -->
+	<xsl:template match="node() | @*" >
+		<xsl:copy>
+			<xsl:apply-templates select="node() | @*" />
+		</xsl:copy>
+	</xsl:template>
+	
+</xsl:stylesheet>

--- a/fixes.py
+++ b/fixes.py
@@ -1,6 +1,6 @@
 import json
 
-from os.path import join
+from pathlib import Path
 
 import arcgis
 import arcpy
@@ -209,12 +209,12 @@ class ItemFixer:
         fc_path = self.item_report['metadata_new']
 
         arcpy_metadata = arcpy.metadata.Metadata(fc_path)
-        metadata_xml_path = join(arcpy.env.scratchFolder, 'md.xml')
+        metadata_xml_path = Path(arcpy.env.scratchFolder, 'md.xml')
 
-        arcpy_metadata.saveAsUsingCustomXSLT(metadata_xml_path, xml_template)
+        arcpy_metadata.saveAsUsingCustomXSLT(str(metadata_xml_path), xml_template)
 
         try:
-            self.item.update(metadata = metadata_xml_path)
+            self.item.update(metadata = str(metadata_xml_path))
 
             if self.item.metadata != arcpy_metadata.xml:
                 self.item_report['metadata_result'] = f'Tried to update metadata from "{fc_path}; verify manually"'
@@ -225,8 +225,8 @@ class ItemFixer:
             return
 
         finally:
-            if arcpy.Exists(metadata_xml_path):
-                arcpy.management.Delete(metadata_xml_path)
+            if metadata_xml_path.exists():
+                metadata_xml_path.unlink()
 
         self.item_report['metadata_result'] = f'Metadata updated from "{fc_path}"'
 

--- a/fixes.py
+++ b/fixes.py
@@ -214,7 +214,7 @@ class ItemFixer:
         arcpy_metadata.saveAsUsingCustomXSLT(metadata_xml_path, xml_template)
 
         try:
-            self.item.update(metadata = metadata_xml_path
+            self.item.update(metadata = metadata_xml_path)
 
             if self.item.metadata != arcpy_metadata.xml:
                 self.item_report['metadata_result'] = f'Tried to update metadata from "{fc_path}; verify manually"'

--- a/validate.py
+++ b/validate.py
@@ -76,6 +76,8 @@ class Validator:
 
         self.username = credentials.USERNAME
 
+        self.metadata_xml_template = credentials.XML_TEMPLATE
+
         try:
             self.gis = arcgis.gis.GIS(credentials.ORG, credentials.USERNAME, credentials.PASSWORD)
 
@@ -237,7 +239,7 @@ class Validator:
 
                 fixer = fixes.ItemFixer(item, item_report)
 
-                fixer.metadata_fix()
+                fixer.metadata_fix(self.metadata_xml_template)
                 fixer.tags_fix()
                 fixer.title_fix()
                 fixer.group_fix(self.groups_dict)

--- a/validate.py
+++ b/validate.py
@@ -28,7 +28,7 @@ class Validator:
     '''
 
     #: Tags or words that should be uppercased, saved as lower to check against
-    uppercased_tags = ['2g', '3g', '4g', 'agol', 'agrc', 'aog', 'at&t', 'blm', 'brat', 'caf', 'cdl', 'daq', 'dfcm', 'dfirm', 'dwq', 'e911', 'ems', 'fae', 'fcc', 'fema', 'gcdb', 'gis', 'gnis', 'hava', 'huc', 'lir', 'lrs', 'lte', 'luca', 'mrrc', 'nca', 'ng911', 'nox', 'npsbn', 'ntia', 'nwi', 'pli', 'plss', 'pm10', 'psap', 'sao', 'sbdc', 'sbi', 'sgid', 'sitla', 'sligp', 'trax', 'uca', 'udot', 'ugs', 'uhp', 'uic', 'us', 'usao', 'usdw', 'usfs', 'usfws', 'usps', 'ustc', 'ut', 'uta', 'vcp', 'vista', 'voc']
+    uppercased_tags = ['2g', '3g', '4g', 'agol', 'agrc', 'aog', 'at&t', 'blm', 'brat', 'caf', 'cdl', 'daq', 'dfcm', 'dfirm', 'dwq', 'e911', 'ems', 'fae', 'fcc', 'fema', 'gcdb', 'gis', 'gnis', 'hava', 'huc', 'lir', 'lrs', 'lte', 'luca', 'mrrc', 'nca', 'ng911', 'nox', 'npsbn', 'ntia', 'nwi', 'pli', 'plss', 'pm10', 'psap', 'sao', 'sbdc', 'sbi', 'sgid', 'sitla', 'sligp', 'trax', 'uca', 'udot', 'ugs', 'uhp', 'uic', 'uipa', 'us', 'usao', 'usdw', 'usfs', 'usfws', 'usps', 'ustc', 'ut', 'uta', 'vcp', 'vista', 'voc']
 
     #: Articles that should be left lowercase.
     articles = ['a', 'the', 'of', 'is', 'in']

--- a/validate.py
+++ b/validate.py
@@ -6,7 +6,7 @@ See __main__.py for usage
 
 import datetime
 
-from os.path import join
+from pathlib import Path
 from urllib.error import HTTPError
 
 import pandas as pd
@@ -212,7 +212,7 @@ class Validator:
         finally:
             #: Convert dict to pandas df for easy writing
             if report_dir:
-                report_path = join(report_dir, f'checks_{datetime.date.today()}.csv')
+                report_path = Path(report_dir, f'checks_{datetime.date.today()}.csv')
                 report_df = pd.DataFrame(self.report_dict).T
                 report_df.to_csv(report_path)
 
@@ -287,7 +287,7 @@ class Validator:
         finally:
             #: Convert dict to pandas df for easy writing
             if report_dir:
-                report_path = join(report_dir, f'fixes_{datetime.date.today()}.csv')
+                report_path = Path(report_dir, f'fixes_{datetime.date.today()}.csv')
                 report_df = pd.DataFrame(self.report_dict).T
                 report_df.to_csv(report_path)
 

--- a/validate.py
+++ b/validate.py
@@ -28,7 +28,7 @@ class Validator:
     '''
 
     #: Tags or words that should be uppercased, saved as lower to check against
-    uppercased_tags = ['2g', '3g', '4g', 'agol', 'agrc', 'aog', 'at&t', 'blm', 'brat', 'caf', 'cdl', 'daq', 'dfcm', 'dfirm', 'dwq', 'e911', 'ems', 'fae', 'fcc', 'fema', 'gcdb', 'gis', 'gnis', 'hava', 'huc', 'lir', 'lrs', 'lte', 'luca', 'mrrc', 'nca', 'ng911', 'nox', 'npsbn', 'ntia', 'nwi', 'plss', 'pm10', 'psap', 'sao', 'sbdc', 'sbi', 'sgid', 'sitla', 'sligp', 'trax', 'uca', 'udot', 'ugs', 'uhp', 'uic', 'us', 'usao', 'usdw', 'usfs', 'usfws', 'usps', 'ustc', 'ut', 'uta', 'vcp', 'vista', 'voc']
+    uppercased_tags = ['2g', '3g', '4g', 'agol', 'agrc', 'aog', 'at&t', 'blm', 'brat', 'caf', 'cdl', 'daq', 'dfcm', 'dfirm', 'dwq', 'e911', 'ems', 'fae', 'fcc', 'fema', 'gcdb', 'gis', 'gnis', 'hava', 'huc', 'lir', 'lrs', 'lte', 'luca', 'mrrc', 'nca', 'ng911', 'nox', 'npsbn', 'ntia', 'nwi', 'pli', 'plss', 'pm10', 'psap', 'sao', 'sbdc', 'sbi', 'sgid', 'sitla', 'sligp', 'trax', 'uca', 'udot', 'ugs', 'uhp', 'uic', 'us', 'usao', 'usdw', 'usfs', 'usfws', 'usps', 'ustc', 'ut', 'uta', 'vcp', 'vista', 'voc']
 
     #: Articles that should be left lowercase.
     articles = ['a', 'the', 'of', 'is', 'in']

--- a/validate.py
+++ b/validate.py
@@ -239,6 +239,9 @@ class Validator:
 
                 fixer = fixes.ItemFixer(item, item_report)
 
+                #: Do the metadata fix first so that the tags, title, and
+                #: description fixes later on aren't overwritten by the metadata
+                #: upload.
                 fixer.metadata_fix(self.metadata_xml_template)
                 fixer.tags_fix()
                 fixer.title_fix()


### PR DESCRIPTION
Changes metadata upload by creating a temporary xml file of the SDE metadata with the `exact copy of.xslt` template, updating the AGOL metadata with the xml file, and then deletes the xml file. 

Creating the temp xml file with the template seems to ensure that the metadata matches the ArcGIS Metadata format as required for AGOL metdata updates (https://doc.arcgis.com/en/arcgis-online/manage-data/metadata.htm#ESRI_SECTION1_CE02409EE61D4A51A2BB943A2D8D982F). This may still not work if the SDE metadata is "in an older format and needs to be upgraded before it can be viewed in Pro", etc. However, for those feature classes whose metadata are in that format, this should improve the success rate of metadata uploads.