### PR TITLE
fix: lowercased tags in title, new uppercased tags

### DIFF
--- a/checks.py
+++ b/checks.py
@@ -169,8 +169,9 @@ class ItemChecker:
             #: to be checked later.
 
             #: single-word tag in title
+            #: Safe to use lower case for single-word tags
             single_word_tag_in_title = False
-            if orig_tag in title.split():
+            if orig_tag.lower() in title.lower().split():
                 single_word_tag_in_title = True
             #: multi-word tag in title
             multi_word_tag_in_title = False

--- a/validate.py
+++ b/validate.py
@@ -28,13 +28,13 @@ class Validator:
     '''
 
     #: Tags or words that should be uppercased, saved as lower to check against
-    uppercased_tags = ['2g', '3g', '4g', 'agol', 'agrc', 'aog', 'at&t', 'blm', 'brat', 'caf', 'cdl', 'daq', 'dfcm', 'dfirm', 'dwq', 'e911', 'ems', 'fae', 'fcc', 'fema', 'gcdb', 'gis', 'gnis', 'hava', 'huc', 'lir', 'lrs', 'lte', 'luca', 'mrrc', 'nca', 'ng911', 'nox', 'npsbn', 'ntia', 'nwi', 'pli', 'plss', 'pm10', 'psap', 'sao', 'sbdc', 'sbi', 'sgid', 'sitla', 'sligp', 'trax', 'uca', 'udot', 'ugs', 'uhp', 'uic', 'uipa', 'us', 'usao', 'usdw', 'usfs', 'usfws', 'usps', 'ustc', 'ut', 'uta', 'vcp', 'vista', 'voc']
+    uppercased_tags = ['2g', '3g', '4g', 'agol', 'agrc', 'aog', 'at&t', 'atv', 'blm', 'brat', 'caf', 'cdl', 'daq', 'dfcm', 'dfirm', 'dnr', 'dogm', 'dsl', 'dwq', 'e911', 'ems', 'epa', 'fae', 'fcc', 'fema', 'gcdb', 'gis', 'gnis', 'hava', 'huc', 'lir', 'lrs', 'lte', 'luca', 'mrrc', 'nca', 'ng911', 'nox', 'npsbn', 'ntia', 'nwi', 'pli', 'plss', 'pm10', 'psap', 'sao', 'sbdc', 'sbi', 'sgid', 'sitla', 'sligp', 'trax', 'uca', 'udot', 'ugs', 'uhp', 'uic', 'uipa', 'us', 'usao', 'usdw', 'usfs', 'usfws', 'usps', 'ustc', 'ut', 'uta', 'vcp', 'vista', 'voc', 'wre']
 
     #: Articles that should be left lowercase.
-    articles = ['a', 'the', 'of', 'is', 'in']
+    articles = ['a', 'an', 'the', 'of', 'is', 'in']
 
     #: Tags that should be deleted
-    tags_to_delete = ['.sd', 'service definition']
+    tags_to_delete = ['.sd', 'service definition', 'Required: Common-Use Word Or Phrase Used To Describe the Subject of the Data Set']
 
     #: Notes for static and shelved descriptions
     static_note = "<i><b>NOTE</b>: This dataset holds 'static' data that we don't expect to change. We have removed it from the SDE database and placed it in ArcGIS Online, but it is still considered part of the SGID and shared on opendata.gis.utah.gov.</i>"


### PR DESCRIPTION
- Remove any lower cased tags that are proper cased in the title ('upload' in 'Utah AGOL Upload Test'). 
- Added several new acronyms to the list of tags to uppercase.
- Remove placeholder tag instructing users how to add tags.